### PR TITLE
Add project tracker for concrete mix designs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.py[cod]
+.pytest_cache/

--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
 # hello-world
-ye old repository
-Chrisopheropherson here, my cat snores really loudly. I wake her up sometimes so she'll stop for a moment.
+
+This repository now includes a simple command-line application for tracking concrete projects and their mix designs.
+
+## Usage
+
+Run the project tracker:
+
+```bash
+python project_tracker.py
+```
+
+You will be prompted for the project name, location and any mix designs. If only one mix design is provided it is automatically set as the default. When multiple mix designs are entered you can choose which one should be the default.

--- a/project_tracker.py
+++ b/project_tracker.py
@@ -1,0 +1,70 @@
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+
+@dataclass
+class MixDesign:
+    """Represents a concrete mix design."""
+    name: str
+
+
+@dataclass
+class Project:
+    """Represents a project with concrete mix designs."""
+    name: str
+    location: str
+    mix_designs: List[MixDesign] = field(default_factory=list)
+    default_mix_design: Optional[MixDesign] = None
+
+    def add_mix_design(self, mix_design: MixDesign, *, is_default: bool = False) -> None:
+        """Add a mix design to the project.
+
+        The first mix design added becomes the default unless another default
+        is explicitly specified.
+        """
+        self.mix_designs.append(mix_design)
+        if is_default or len(self.mix_designs) == 1:
+            self.default_mix_design = mix_design
+
+    def set_default_mix_design(self, mix_design_name: str) -> None:
+        """Set the default mix design by name.
+
+        Raises:
+            ValueError: If the mix design name does not exist in the project.
+        """
+        for md in self.mix_designs:
+            if md.name == mix_design_name:
+                self.default_mix_design = md
+                return
+        raise ValueError(f"Mix design '{mix_design_name}' not found.")
+
+
+def create_project_from_input() -> Project:
+    """Interactively create a project via command-line inputs."""
+    name = input("Project name: ")
+    location = input("Project location: ")
+    project = Project(name=name, location=location)
+
+    while True:
+        add_mix = input("Add a mix design? (y/n): ").strip().lower()
+        if add_mix != 'y':
+            break
+        mix_name = input("Mix design name: ").strip()
+        project.add_mix_design(MixDesign(name=mix_name))
+
+    if len(project.mix_designs) > 1:
+        default_name = input("Select default mix design: ").strip()
+        project.set_default_mix_design(default_name)
+
+    print("\nCreated Project:")
+    print(f"Name: {project.name}")
+    print(f"Location: {project.location}")
+    print("Mix Designs:")
+    for md in project.mix_designs:
+        default_marker = " (default)" if md == project.default_mix_design else ""
+        print(f" - {md.name}{default_marker}")
+    return project
+
+
+if __name__ == "__main__":
+    create_project_from_input()

--- a/tests/test_project_tracker.py
+++ b/tests/test_project_tracker.py
@@ -1,0 +1,17 @@
+import sys
+from pathlib import Path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from project_tracker import Project, MixDesign
+
+def test_single_mix_design_becomes_default():
+    project = Project(name="Test Project", location="Location")
+    project.add_mix_design(MixDesign("Mix A"))
+    assert project.default_mix_design.name == "Mix A"
+
+def test_set_default_mix_design_when_multiple():
+    project = Project(name="Test Project", location="Location")
+    project.add_mix_design(MixDesign("Mix A"))
+    project.add_mix_design(MixDesign("Mix B"))
+    project.set_default_mix_design("Mix B")
+    assert project.default_mix_design.name == "Mix B"


### PR DESCRIPTION
## Summary
- add `project_tracker.py` with Project and MixDesign classes and CLI
- document app usage in README
- add tests for default mix design selection

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689fedb5eaa883268972231b23999cc5